### PR TITLE
Collect command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,6 +75,20 @@
         "/Users/stijn/Google Drive/lsdj/4ntler"
       ],
       "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug LSDJ Tools – Collect",
+      "cargo": {
+        "args": ["build", "--bin=lsdj-tools", "--package=lsdj-tools"],
+        "filter": {
+          "name": "lsdj-tools",
+          "kind": "bin"
+        }
+      },
+      "args": ["collect", "/Users/stijn/Desktop/lsdj"],
+      "cwd": "${workspaceFolder}"
     }
   ]
 }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -15,5 +15,9 @@ version = "0.1.1"
 anyhow = "1.0.56"
 clap = { version = "4.5.38", features = ["derive"] }
 lsdj = { version = "0.1.0", path = "../lsdj" }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 walkdir = "2.3.2"
 wild = "2.0.4"
+colored = "3.0.0"
+sha2 = "0.10.9"

--- a/tools/README.md
+++ b/tools/README.md
@@ -107,6 +107,50 @@ OPTIONS:
 Wrote test.sav
 ```
 
+## Collect
+
+Collect goes through a set of files and folders, and matches songs together by their name.
+
+It then lists all versions it has found per song, and in which file it has found them.
+
+The second column shows a SHA-256 hash of the song contents, to be able to compare them to other versions.
+
+Collect is also capable of writing this data to a json file instead.
+
+```console
+Usage: lsdj-tools collect [OPTIONS] [PATHS]...
+
+Arguments:
+  [PATHS]...
+          The paths to walk and check for songs
+
+Options:
+  -r, --recursive
+          Should folders be walked recursively
+
+      --json <JSON>
+          A JSON file the outcome should be written to
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```
+
+### Example
+
+```console
+4ntler@mbp > lsdj-tools collect ./best_songs_ever
+BREATHE
+  v003 86 /usr/best_songs_ever/lsdj9_2_L.sav[0]
+  v002 43 /usr/best_songs_ever/lsdj9_2_A.sav[0]
+
+SUN
+  v004 f3 /usr/best_songs_ever/lsdj9_4_0_sun.sav[1]
+  v004 f3 /usr/best_songs_ever/lsdj9_4_0.sav[1]
+```
+
 ## Support
 
 If you like this crate and want to support me somehow, consider buying some of [my music](https://4ntler.bandcamp.com/).

--- a/tools/src/collect.rs
+++ b/tools/src/collect.rs
@@ -1,0 +1,231 @@
+//! The `collect` subcommand
+
+use crate::utils::iter_files;
+use anyhow::{Context, Result};
+use clap::Args;
+use colored::Colorize;
+use lsdj::{fs::File, lsdsng::LsdSng, sram::SRam};
+use serde::{Serialize, Serializer};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::PathBuf,
+};
+
+/// Arguments for the `collect` subcommand
+#[derive(Args)]
+#[clap(
+    author,
+    version,
+    about = "Collect all versions of a (set of) song and print them",
+    long_about = "Collect goes through a set of files and folders, and matches songs together by their name.\n\nIt then lists all versions it has found per song, and in which file it has found them.\n\nThe second column shows a SHA-256 hash of the song contents, to be able to compare them to other versions.\n\nCollect is also capable of writing this data to a json file instead."
+)]
+pub struct CollectArgs {
+    /// The paths to walk and check for songs
+    paths: Vec<PathBuf>,
+
+    /// Should folders be walked recursively
+    #[clap(short, long)]
+    recursive: bool,
+
+    /// A JSON file the outcome should be written to
+    #[clap(long)]
+    json: Option<PathBuf>,
+}
+
+/// Collect all versions of a (set of) song and print them
+pub fn collect(args: CollectArgs) -> Result<()> {
+    // Collect the songs
+    let outcome = collect_songs(args.paths, args.recursive);
+
+    // Go over the songs and print the songs we found
+    if let Some(path) = args.json {
+        let parent = path.parent().unwrap();
+        fs::create_dir_all(parent)
+            .context(format!("Could not create folder at {}", parent.display()))?;
+
+        let file = fs::File::create(&path)
+            .context(format!("Could not create file at {}", path.display()))?;
+
+        serde_json::to_writer_pretty(file, &outcome).context("Could not write to JSON")?;
+
+        println!("Wrote to {}", path.display());
+    } else {
+        print_outcome(outcome);
+    }
+
+    Ok(())
+}
+
+fn collect_songs(paths: Vec<PathBuf>, recursive: bool) -> Outcome {
+    let mut outcome = Outcome::default();
+
+    // Collect the instances
+    for entry in iter_files(paths, recursive, &["sav"]) {
+        let path = entry.path();
+
+        if let Some(extension) = path.extension() {
+            if extension == "sav" {
+                if let Ok(sram) = SRam::from_path(path) {
+                    for (index, entry) in sram.filesystem.files().enumerate() {
+                        if let Some(entry) = entry {
+                            let name = entry.name().unwrap().as_str().to_owned();
+                            let source = Source::Sav {
+                                path: path.to_owned(),
+                                index,
+                            };
+                            match file_to_instance(&entry, source.clone()) {
+                                Some(instance) => {
+                                    outcome.songs.entry(name).or_default().push(instance);
+                                }
+                                None => outcome.errors.push(source),
+                            }
+                        }
+                    }
+                }
+            } else if extension == "lsdsng" {
+                if let Ok(lsdsng) = LsdSng::from_path(path) {
+                    let name = lsdsng.name().unwrap().as_str().to_owned();
+                    let source = Source::LsdSng {
+                        path: path.to_owned(),
+                    };
+
+                    match file_to_instance(&lsdsng, source.clone()) {
+                        Some(instance) => {
+                            outcome.songs.entry(name).or_default().push(instance);
+                        }
+                        None => outcome.errors.push(source),
+                    }
+                }
+            }
+        }
+    }
+
+    outcome
+}
+
+fn file_to_instance(file: &impl File, source: Source) -> Option<Instance> {
+    let version = file.version();
+    let song = file.decompress().ok()?;
+    let sha = Sha256::digest(song.as_slice());
+
+    Some(Instance {
+        version,
+        sha256: sha.into(),
+        source,
+    })
+}
+
+fn print_outcome(outcome: Outcome) {
+    let mut first = true;
+
+    for source in outcome.errors {
+        match source {
+            Source::LsdSng { path } => {
+                println!("Could not decompress {}", path.display());
+            }
+            Source::Sav { path, index } => {
+                println!(
+                    "Could not decompress {}[{}]",
+                    path.display(),
+                    index.to_string().blue()
+                );
+            }
+        }
+    }
+
+    for (name, mut instances) in outcome.songs {
+        if first {
+            first = false;
+        } else {
+            println!();
+        }
+
+        println!("{}", name.bold());
+
+        instances.sort_by_key(|instance| instance.version);
+        instances.reverse();
+
+        // Collect the hash strings
+        let shas = instances
+            .iter()
+            .map(|instance| &instance.sha256)
+            .collect::<HashSet<_>>();
+        let unique_sha_length = find_min_len(shas);
+
+        for instance in instances {
+            let version = format!("v{:03}", instance.version).green();
+            let sha = bytes_to_string(&instance.sha256);
+            let sha = sha[..unique_sha_length * 2].dimmed();
+
+            match instance.source {
+                Source::LsdSng { path } => {
+                    println!("  v{version} {sha} {}", path.display());
+                }
+                Source::Sav { path, index } => {
+                    println!(
+                        "  {version} {sha} {}[{}]",
+                        path.display(),
+                        index.to_string().blue()
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn bytes_to_string(sha: &[u8; 32]) -> String {
+    sha.iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
+/// The minimum amount of bytes needed to uniquely identify each byte string in a set
+fn find_min_len(strings: HashSet<&[u8; 32]>) -> usize {
+    let mut unique_length = 0;
+    let mut seen = HashSet::new();
+
+    for i in 0..32 {
+        for string in &strings {
+            let prefix = &string[..=i];
+            if seen.insert(prefix) {
+                unique_length = i + 1;
+            }
+        }
+        if unique_length == i + 1 {
+            break;
+        }
+    }
+
+    unique_length
+}
+
+#[derive(Default, Serialize)]
+struct Outcome {
+    pub songs: HashMap<String, Vec<Instance>>,
+    pub errors: Vec<Source>,
+}
+
+#[derive(Serialize)]
+struct Instance {
+    version: u8,
+
+    #[serde(serialize_with = "sha_serialize")]
+    sha256: [u8; 32],
+    source: Source,
+}
+
+fn sha_serialize<S>(x: &[u8; 32], s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(&bytes_to_string(x))
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Source {
+    LsdSng { path: PathBuf },
+    Sav { path: PathBuf, index: usize },
+}

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -106,7 +106,52 @@
 //! 01 => banger2.lsdsng
 //! Wrote test.sav
 //! ```
+//!
+//! ## Collect
+//!
+//! Collect goes through a set of files and folders, and matches songs together by their name.
+//!
+//! It then lists all versions it has found per song, and in which file it has found them.
+//!
+//! The second column shows a SHA-256 hash of the song contents, to be able to compare them to other versions.
+//!
+//! Collect is also capable of writing this data to a json file instead.
+//!
+//! ```console
+//! Usage: lsdj-tools collect [OPTIONS] [PATHS]...
+//!
+//! Arguments:
+//!   [PATHS]...
+//!           The paths to walk and check for songs
+//!
+//! Options:
+//!   -r, --recursive
+//!           Should folders be walked recursively
+//!
+//!       --json <JSON>
+//!           A JSON file the outcome should be written to
+//!
+//!   -h, --help
+//!           Print help (see a summary with '-h')
+//!
+//!   -V, --version
+//!           Print version
+//! ```
+//!
+//! ### Example
+//!
+//! ```console
+//! 4ntler@mbp > lsdj-tools collect ./best_songs_ever
+//! BREATHE
+//!   v003 86 /usr/best_songs_ever/lsdj9_2_L.sav[0]
+//!   v002 43 /usr/best_songs_ever/lsdj9_2_A.sav[0]
+//!
+//! SUN
+//!   v004 f3 /usr/best_songs_ever/lsdj9_4_0_sun.sav[1]
+//!   v004 f3 /usr/best_songs_ever/lsdj9_4_0.sav[1]
+//! ```
 
+pub mod collect;
 pub mod export;
 pub mod import;
 pub mod inspect;

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 
+use lsdj_tools::collect::{CollectArgs, collect};
 use lsdj_tools::export::{ExportArgs, export};
 use lsdj_tools::import::{ImportArgs, import};
 use lsdj_tools::inspect::{InspectArgs, inspect};
@@ -11,6 +12,7 @@ enum Cli {
     Inspect(InspectArgs),
     Export(ExportArgs),
     Import(ImportArgs),
+    Collect(CollectArgs),
 }
 
 fn main() -> Result<()> {
@@ -18,5 +20,6 @@ fn main() -> Result<()> {
         Cli::Inspect(args) => inspect(&args),
         Cli::Export(args) => export(args),
         Cli::Import(args) => import(args),
+        Cli::Collect(args) => collect(args),
     }
 }


### PR DESCRIPTION
This PR introduces a new command to lsdj-tools: `collect`. Provided a bunch of paths, the command will:

  - Recursively search the paths for `.sav` and `.lsdsng` files
  - Read in all songs
  - Collect the songs and sort them per name
  - Print out all the instances of each song it could find, and what the versions exist
  
The command is also capable of writing the output to a JSON file, for further processing.